### PR TITLE
SM-5577: Add linting rules for const, blank lines and trailing commas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2906,15 +2906,15 @@
       }
     },
     "tslib": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
       "dev": true
     },
     "tslint": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
-      "integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.2.tgz",
+      "integrity": "sha512-UyNrLdK3E0fQG/xWNqAFAC5ugtFyPO4JJR1KyyfQAyzR8W0fTRrC91A8Wej4BntFzcvETdCSDa/4PnNYJQLYiA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -2925,10 +2925,10 @@
         "glob": "^7.1.1",
         "js-yaml": "^3.13.1",
         "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
+        "mkdirp": "^0.5.3",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
-        "tslib": "^1.8.0",
+        "tslib": "^1.10.0",
         "tsutils": "^2.29.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "build": "npm run clean && tsc",
     "clean": "rimraf dist",
     "lint": "tslint --project tslint.json --exclude 'prod_node_modules/**'",
+    "lint-fix": "tslint --project tslint.json --exclude 'node_modules/**' --exclude 'prod_node_modules/**' --fix",
     "job-1": "node ./dist/job-1/app.js",
     "test": "TZ=UTC npm run lint && nyc npm run test-unit",
     "test-unit": "TZ=UTC mocha 'tests/unit/**/*.ts' --require ts-node/register",
@@ -35,7 +36,7 @@
     "sinon": "^7.3.2",
     "ts-mockito": "^2.3.1",
     "ts-node": "^7.0.1",
-    "tslint": "^5.11.0",
+    "tslint": "^6.1.2",
     "typescript": "^3.8.3"
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -37,7 +37,7 @@
     "no-arg": true,
     "no-bitwise": false,
     "no-conditional-assignment": true,
-    "no-consecutive-blank-lines": false,
+    "no-consecutive-blank-lines": true,
     "no-construct": true,
     "no-constructor-vars": false,
     "no-debugger": true,
@@ -72,6 +72,7 @@
     "radix": true,
     "semicolon": [true, "never"],
     "switch-default": true,
+    "prefer-const": true,
     "triple-equals": [
       true,
       "allow-null-check"
@@ -107,6 +108,13 @@
       "check-operator",
       "check-separator",
       "check-type"
+    ],
+    "trailing-comma": [
+      true,
+      {
+        "multiline": "never",
+        "singleline": "never"
+      }
     ]
   }
 }


### PR DESCRIPTION
## Description

Add linting rules:
https://palantir.github.io/tslint/rules/trailing-comma
https://palantir.github.io/tslint/rules/eofline
https://palantir.github.io/tslint/rules/no-consecutive-blank-lines
https://palantir.github.io/tslint/rules/prefer-const/

## Checklist

- [ ] All unit tests passing
- [ ] All integration tests passing
- [ ] Code coverage suitable
- [ ] Branch named {feature|hotfix|task}/{SM-.*}
- [ ] If your pull request depends on any other, please link them
- [ ] Changes approved by your team
- [ ] Changes approved by another team
- [ ] Commit messages are meaningful
- [ ] I have read and understand the [Jobs release process](https://github.com/departmentfortransport/street-manager-jobs#release-process)
- [ ] Target is green https://circleci.com/gh/departmentfortransport/street-manager-jobs/tree/master
- [ ] Int UI tests passing https://circleci.com/gh/departmentfortransport/street-manager-int/tree/master
- [ ] Add `DO NOT MERGE` if you want to postpone merge
