### PR TITLE
feature/SM-6313: add issued sample inspection status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1618,9 +1618,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "lodash.flattendeep": {
@@ -2776,61 +2776,14 @@
       }
     },
     "street-manager-data": {
-      "version": "git+ssh://git@github.com/departmentfortransport/street-manager-data.git#1fef17fea08741fea9ba07749ebbb8a3a0973731",
-      "from": "git+ssh://git@github.com/departmentfortransport/street-manager-data.git#1fef17fea08741fea9ba07749ebbb8a3a0973731",
+      "version": "git+ssh://git@github.com/departmentfortransport/street-manager-data.git#961a6983d0618e4181ad65e2a0ad05f2154be208",
+      "from": "git+ssh://git@github.com/departmentfortransport/street-manager-data.git#961a6983d0618e4181ad65e2a0ad05f2154be208",
       "requires": {
         "@types/geojson": "^7946.0.7",
         "knex": "^0.21.5",
         "pg": "^8.3.3"
       },
       "dependencies": {
-        "colorette": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
-          "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw=="
-        },
-        "commander": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
-        },
-        "interpret": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
-          "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw=="
-        },
-        "knex": {
-          "version": "0.21.5",
-          "resolved": "https://registry.npmjs.org/knex/-/knex-0.21.5.tgz",
-          "integrity": "sha512-cQj7F2D/fu03eTr6ZzYCYKdB9w7fPYlvTiU/f2OeXay52Pq5PwD+NAkcf40WDnppt/4/4KukROwlMOaE7WArcA==",
-          "requires": {
-            "colorette": "1.2.1",
-            "commander": "^5.1.0",
-            "debug": "4.1.1",
-            "esm": "^3.2.25",
-            "getopts": "2.2.5",
-            "inherits": "~2.0.4",
-            "interpret": "^2.2.0",
-            "liftoff": "3.1.0",
-            "lodash": "^4.17.20",
-            "mkdirp": "^1.0.4",
-            "pg-connection-string": "2.3.0",
-            "tarn": "^3.0.0",
-            "tildify": "2.0.0",
-            "uuid": "^7.0.3",
-            "v8flags": "^3.2.0"
-          }
-        },
-        "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
-        },
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-        },
         "pg": {
           "version": "8.3.3",
           "resolved": "https://registry.npmjs.org/pg/-/pg-8.3.3.tgz",
@@ -2846,11 +2799,6 @@
             "semver": "4.3.2"
           }
         },
-        "pg-connection-string": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.3.0.tgz",
-          "integrity": "sha512-ukMTJXLI7/hZIwTW7hGMZJ0Lj0S2XQBCJ4Shv4y1zgQ/vqVea+FLhzywvPj0ujSuofu+yA4MYHGZPTsgjBgJ+w=="
-        },
         "pg-pool": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.2.1.tgz",
@@ -2860,19 +2808,6 @@
           "version": "1.2.5",
           "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.2.5.tgz",
           "integrity": "sha512-1uYCckkuTfzz/FCefvavRywkowa6M5FohNMF5OjKrqo9PSR8gYc8poVmwwYQaBxhmQdBjhtP514eXy9/Us2xKg=="
-        },
-        "tarn": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.0.0.tgz",
-          "integrity": "sha512-PKUnlDFODZueoA8owLehl8vLcgtA8u4dRuVbZc92tspDYZixjJL6TqYOmryf/PfP/EBX+2rgNcrj96NO+RPkdQ=="
-        },
-        "v8flags": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz",
-          "integrity": "sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==",
-          "requires": {
-            "homedir-polyfill": "^1.0.1"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "moment-timezone": "^0.5.28",
     "pg": "^8.0.3",
     "reflect-metadata": "^0.1.13",
-    "street-manager-data": "git+ssh://git@github.com:departmentfortransport/street-manager-data#1fef17fea08741fea9ba07749ebbb8a3a0973731"
+    "street-manager-data": "git+ssh://git@github.com:departmentfortransport/street-manager-data#961a6983d0618e4181ad65e2a0ad05f2154be208"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",

--- a/src/generate-sample-inspections/daos/sampleInspectionDao.ts
+++ b/src/generate-sample-inspections/daos/sampleInspectionDao.ts
@@ -1,6 +1,6 @@
 import * as Knex from 'knex'
 import { inject, injectable } from 'inversify'
-import { SampleInspection } from 'street-manager-data'
+import { RefInspectionCategory, RefSampleInspectionStatus, SampleInspection } from 'street-manager-data'
 import TYPES from '../types'
 
 @injectable()
@@ -67,7 +67,8 @@ export default class SampleInspectionDao {
           'eligible_works.work_id',
           'eligible_works.promoter_organisation_id',
           'eligible_works.work_end_date AS expiry_date',
-          this.knex.raw('1 AS inspection_category_id')
+          this.knex.raw(`${RefInspectionCategory.a} AS inspection_category_id`),
+          this.knex.raw(`${RefSampleInspectionStatus.issued} AS sample_inspection_status_id`)
       )
       .from(this.getCategoryAEligibleWorks(organisationId))
       .whereRaw(`eligible_works.row_num <= eligible_works.category_a_to_generate`)
@@ -80,8 +81,9 @@ export default class SampleInspectionDao {
         'eligible_works.sample_inspection_target_id',
         'eligible_works.work_id',
         'eligible_works.promoter_organisation_id',
-        this.knex.raw('MAX(eligible_works.reinstatement_date) AS expiry_date'),
-        this.knex.raw('2 AS inspection_category_id')
+        this.knex.raw(`MAX(eligible_works.reinstatement_date) + interval '6 months' AS expiry_date`),
+        this.knex.raw(`${RefInspectionCategory.b} AS inspection_category_id`),
+        this.knex.raw(`${RefSampleInspectionStatus.issued} AS sample_inspection_status_id`)
       )
       .from(this.getCategoryBEligibleWorks(organisationId))
       .whereRaw(`eligible_works.row_num <= eligible_works.category_b_to_generate`)
@@ -96,7 +98,8 @@ export default class SampleInspectionDao {
         'eligible_works.work_id',
         'eligible_works.promoter_organisation_id',
         this.knex.raw('MAX(eligible_works.end_date) AS expiry_date'),
-        this.knex.raw('3 AS inspection_category_id')
+        this.knex.raw(`${RefInspectionCategory.c} AS inspection_category_id`),
+        this.knex.raw(`${RefSampleInspectionStatus.issued} AS sample_inspection_status_id`)
       )
       .from(this.getCategoryCEligibleWorks(organisationId))
       .whereRaw(`eligible_works.row_num <= eligible_works.category_c_to_generate`)

--- a/tests/fixtures/sampleInspectionFixtures.ts
+++ b/tests/fixtures/sampleInspectionFixtures.ts
@@ -1,4 +1,4 @@
-import { SampleInspection, RefInspectionCategory } from 'street-manager-data'
+import { SampleInspection, RefInspectionCategory, RefSampleInspectionStatus } from 'street-manager-data'
 
 export function generateSampleInspection(sampleInspectionReferenceNumber = 'SMPL-01', workId = 123, sampleInspectionTargetId = 1): SampleInspection {
   return {
@@ -7,6 +7,7 @@ export function generateSampleInspection(sampleInspectionReferenceNumber = 'SMPL
     inspection_category_id: RefInspectionCategory.a,
     work_id: workId,
     promoter_organisation_id: 11,
-    expiry_date: new Date()
+    expiry_date: new Date(),
+    sample_inspection_status_id: RefSampleInspectionStatus.issued
   }
 }

--- a/tests/integration/generate-sample-inspections/generateSampleInspectionsTests.ts
+++ b/tests/integration/generate-sample-inspections/generateSampleInspectionsTests.ts
@@ -214,7 +214,7 @@ describe('Generate Sample Inspections Job', () => {
       const sampleInspections: Dictionary<SampleInspection> = await runJobAndGetGeneratedSampleInspections([CATEGORY_A_ID, CATEGORY_B_ID, CATEGORY_C_ID])
 
       assertSampleInspection(sampleInspections[workIds[0]], WORK_1_WRN + '-SI-A', activeSampleInspectionTargetIds[0], RefInspectionCategory.a, workIds[0], work1.promoter_organisation_id, work1.work_end_date)
-      assertSampleInspection(sampleInspections[workIds[1]], WORK_2_WRN + '-SI-B', activeSampleInspectionTargetIds[0], RefInspectionCategory.b, workIds[1], work2.promoter_organisation_id, TWO_MONTHS_AGO)
+      assertSampleInspection(sampleInspections[workIds[1]], WORK_2_WRN + '-SI-B', activeSampleInspectionTargetIds[0], RefInspectionCategory.b, workIds[1], work2.promoter_organisation_id, addSixMonthsToDate(TWO_MONTHS_AGO))
       assertSampleInspection(sampleInspections[workIds[2]], WORK_3_WRN + '-SI-C', activeSampleInspectionTargetIds[0], RefInspectionCategory.c, workIds[2], work3.promoter_organisation_id, TWO_MONTHS_FROM_NOW)
     })
 
@@ -225,7 +225,7 @@ describe('Generate Sample Inspections Job', () => {
       const sampleInspections: Dictionary<SampleInspection[]> = groupBy(generatedSampleInspections, 'work_id')
 
       assertSampleInspection(sampleInspections[workIds[3]][0], WORK_4_WRN + '-SI-A', activeSampleInspectionTargetIds[0], RefInspectionCategory.a, workIds[3], work4.promoter_organisation_id, work4.work_end_date)
-      assertSampleInspection(sampleInspections[workIds[3]][1], WORK_4_WRN + '-SI-B', activeSampleInspectionTargetIds[0], RefInspectionCategory.b, workIds[3], work4.promoter_organisation_id, TWO_MONTHS_AGO)
+      assertSampleInspection(sampleInspections[workIds[3]][1], WORK_4_WRN + '-SI-B', activeSampleInspectionTargetIds[0], RefInspectionCategory.b, workIds[3], work4.promoter_organisation_id, addSixMonthsToDate(TWO_MONTHS_AGO))
       assertSampleInspection(sampleInspections[workIds[3]][2], WORK_4_WRN + '-SI-C', activeSampleInspectionTargetIds[0], RefInspectionCategory.c, workIds[3], work4.promoter_organisation_id, TWO_MONTHS_FROM_NOW)
     })
 
@@ -421,7 +421,7 @@ describe('Generate Sample Inspections Job', () => {
     it('for works that do not have scheduled inspections', async () => {
       const sampleInspections: Dictionary<SampleInspection> = await runJobAndGetGeneratedSampleInspections([CATEGORY_B_ID])
 
-      assertSampleInspection(sampleInspections[categoryBWorkIds[0]], CATEGORY_B_WRN + '-SI-B', activeSampleInspectionTargetIds[0], RefInspectionCategory.b, categoryBWorkIds[0], workCategoryB.promoter_organisation_id, reinstatementCategoryB.reinstatement_date)
+      assertSampleInspection(sampleInspections[categoryBWorkIds[0]], CATEGORY_B_WRN + '-SI-B', activeSampleInspectionTargetIds[0], RefInspectionCategory.b, categoryBWorkIds[0], workCategoryB.promoter_organisation_id, addSixMonthsToDate(reinstatementCategoryB.reinstatement_date))
 
       assert.isUndefined(sampleInspections[categoryBWorkIds[1]])
     })
@@ -435,8 +435,8 @@ describe('Generate Sample Inspections Job', () => {
 
       const sampleInspections: Dictionary<SampleInspection> = await runJobAndGetGeneratedSampleInspections([CATEGORY_B_ID])
 
-      assertSampleInspection(sampleInspections[categoryBWorkIds[0]], CATEGORY_B_WRN + '-SI-B', activeSampleInspectionTargetIds[0], RefInspectionCategory.b, categoryBWorkIds[0], workCategoryB.promoter_organisation_id, reinstatementCategoryB.reinstatement_date)
-      assertSampleInspection(sampleInspections[categoryBWorkIds[2]], CATEGORY_B_WRN_WITH_CATEGORY_A_SAMPLE_INSPECTION + '-SI-B', activeSampleInspectionTargetIds[0], RefInspectionCategory.b, categoryBWorkIds[2], workBWithCategoryASampleInspection.promoter_organisation_id, reinstatementCategoryBWithCategoryASampleInspection.reinstatement_date)
+      assertSampleInspection(sampleInspections[categoryBWorkIds[0]], CATEGORY_B_WRN + '-SI-B', activeSampleInspectionTargetIds[0], RefInspectionCategory.b, categoryBWorkIds[0], workCategoryB.promoter_organisation_id, addSixMonthsToDate(reinstatementCategoryB.reinstatement_date))
+      assertSampleInspection(sampleInspections[categoryBWorkIds[2]], CATEGORY_B_WRN_WITH_CATEGORY_A_SAMPLE_INSPECTION + '-SI-B', activeSampleInspectionTargetIds[0], RefInspectionCategory.b, categoryBWorkIds[2], workBWithCategoryASampleInspection.promoter_organisation_id, addSixMonthsToDate(reinstatementCategoryBWithCategoryASampleInspection.reinstatement_date))
 
       assert.isUndefined(sampleInspections[categoryBWorkIds[3]])
     })
@@ -444,7 +444,7 @@ describe('Generate Sample Inspections Job', () => {
     it('for works that have reinstatements carried out less than 6 months ago (one per work)', async () => {
       const sampleInspections: Dictionary<SampleInspection> = await runJobAndGetGeneratedSampleInspections([CATEGORY_B_ID])
 
-      assertSampleInspection(sampleInspections[categoryBWorkIds[0]], CATEGORY_B_WRN + '-SI-B', activeSampleInspectionTargetIds[0], RefInspectionCategory.b, categoryBWorkIds[0], workCategoryB.promoter_organisation_id, reinstatementCategoryB.reinstatement_date)
+      assertSampleInspection(sampleInspections[categoryBWorkIds[0]], CATEGORY_B_WRN + '-SI-B', activeSampleInspectionTargetIds[0], RefInspectionCategory.b, categoryBWorkIds[0], workCategoryB.promoter_organisation_id, addSixMonthsToDate(reinstatementCategoryB.reinstatement_date))
 
       assert.isUndefined(sampleInspections[categoryBWorkIds[4]])
       assert.isUndefined(sampleInspections[categoryBWorkIds[5]])
@@ -453,7 +453,7 @@ describe('Generate Sample Inspections Job', () => {
     it('for works that have excavation reinstatements', async () => {
       const sampleInspections: Dictionary<SampleInspection> = await runJobAndGetGeneratedSampleInspections([CATEGORY_B_ID])
 
-      assertSampleInspection(sampleInspections[categoryBWorkIds[0]], CATEGORY_B_WRN + '-SI-B', activeSampleInspectionTargetIds[0], RefInspectionCategory.b, categoryBWorkIds[0], workCategoryB.promoter_organisation_id, reinstatementCategoryB.reinstatement_date)
+      assertSampleInspection(sampleInspections[categoryBWorkIds[0]], CATEGORY_B_WRN + '-SI-B', activeSampleInspectionTargetIds[0], RefInspectionCategory.b, categoryBWorkIds[0], workCategoryB.promoter_organisation_id, addSixMonthsToDate(reinstatementCategoryB.reinstatement_date))
 
       assert.isUndefined(sampleInspections[categoryBWorkIds[6]])
     })
@@ -461,7 +461,7 @@ describe('Generate Sample Inspections Job', () => {
     it('for the HA org in the job details only', async () => {
       const sampleInspections: Dictionary<SampleInspection> = await runJobAndGetGeneratedSampleInspections([CATEGORY_B_ID])
 
-      assertSampleInspection(sampleInspections[categoryBWorkIds[0]], CATEGORY_B_WRN + '-SI-B', activeSampleInspectionTargetIds[0], RefInspectionCategory.b, categoryBWorkIds[0], workCategoryB.promoter_organisation_id, reinstatementCategoryB.reinstatement_date)
+      assertSampleInspection(sampleInspections[categoryBWorkIds[0]], CATEGORY_B_WRN + '-SI-B', activeSampleInspectionTargetIds[0], RefInspectionCategory.b, categoryBWorkIds[0], workCategoryB.promoter_organisation_id, addSixMonthsToDate(reinstatementCategoryB.reinstatement_date))
 
       assert.isUndefined(sampleInspections[categoryBWorkIds[7]])
     })
@@ -469,8 +469,8 @@ describe('Generate Sample Inspections Job', () => {
     it('for each promoter target for the HA', async () => {
       const sampleInspections: Dictionary<SampleInspection> = await runJobAndGetGeneratedSampleInspections([CATEGORY_B_ID])
 
-      assertSampleInspection(sampleInspections[categoryBWorkIds[0]], CATEGORY_B_WRN + '-SI-B', activeSampleInspectionTargetIds[0], RefInspectionCategory.b, categoryBWorkIds[0], workCategoryB.promoter_organisation_id, reinstatementCategoryB.reinstatement_date)
-      assertSampleInspection(sampleInspections[categoryBWorkIds[8]], CATEGORY_B_WRN_OTHER_PROMOTER + '-SI-B', activeSampleInspectionTargetIds[1], RefInspectionCategory.b, categoryBWorkIds[8], workBOtherPromoter.promoter_organisation_id, reinstatementCategoryBOtherPromoter.reinstatement_date)
+      assertSampleInspection(sampleInspections[categoryBWorkIds[0]], CATEGORY_B_WRN + '-SI-B', activeSampleInspectionTargetIds[0], RefInspectionCategory.b, categoryBWorkIds[0], workCategoryB.promoter_organisation_id, addSixMonthsToDate(reinstatementCategoryB.reinstatement_date))
+      assertSampleInspection(sampleInspections[categoryBWorkIds[8]], CATEGORY_B_WRN_OTHER_PROMOTER + '-SI-B', activeSampleInspectionTargetIds[1], RefInspectionCategory.b, categoryBWorkIds[8], workBOtherPromoter.promoter_organisation_id, addSixMonthsToDate(reinstatementCategoryBOtherPromoter.reinstatement_date))
     })
 
     it('for the cap amount defined in the target', async () => {
@@ -514,8 +514,8 @@ describe('Generate Sample Inspections Job', () => {
     it('with expiry date as the most recent active reinstatement_date for eligible works', async () => {
       const sampleInspections: Dictionary<SampleInspection> = await runJobAndGetGeneratedSampleInspections([CATEGORY_B_ID])
 
-      assertSampleInspection(sampleInspections[categoryBWorkIds[0]], CATEGORY_B_WRN + '-SI-B', activeSampleInspectionTargetIds[0], RefInspectionCategory.b, categoryBWorkIds[0], workCategoryB.promoter_organisation_id, reinstatementCategoryB.reinstatement_date)
-      assertSampleInspection(sampleInspections[categoryBWorkIds[9]], CATEGORY_B_WRN_MULTIPLE_SITES + '-SI-B', activeSampleInspectionTargetIds[0], RefInspectionCategory.b, categoryBWorkIds[9], workBWithMultipleSites.promoter_organisation_id, ONE_WEEK_AGO)
+      assertSampleInspection(sampleInspections[categoryBWorkIds[0]], CATEGORY_B_WRN + '-SI-B', activeSampleInspectionTargetIds[0], RefInspectionCategory.b, categoryBWorkIds[0], workCategoryB.promoter_organisation_id, addSixMonthsToDate(reinstatementCategoryB.reinstatement_date))
+      assertSampleInspection(sampleInspections[categoryBWorkIds[9]], CATEGORY_B_WRN_MULTIPLE_SITES + '-SI-B', activeSampleInspectionTargetIds[0], RefInspectionCategory.b, categoryBWorkIds[9], workBWithMultipleSites.promoter_organisation_id, addSixMonthsToDate(ONE_WEEK_AGO))
     })
 
     after(async () => {
@@ -737,12 +737,16 @@ describe('Generate Sample Inspections Job', () => {
     await deleteJobs(knex, JOB_ID)
   })
 
+  function addSixMonthsToDate(date: Date): Date {
+    return moment(date).add(6, 'months').toDate()
+  }
+
   function assertSampleInspection(sampleInspection: SampleInspection, refNumber: string, targetId: number, inspectionCategory: number, workId: number, promoterOrgId: number, expiryDate: Date) {
     assert.equal(sampleInspection.sample_inspection_reference_number, refNumber)
     assert.equal(sampleInspection.sample_inspection_target_id, targetId)
     assert.equal(sampleInspection.inspection_category_id, inspectionCategory)
     assert.equal(sampleInspection.work_id, workId)
     assert.equal(sampleInspection.promoter_organisation_id, promoterOrgId)
-    assert.deepEqual(sampleInspection.expiry_date, expiryDate)
+    assert.deepEqual(moment(sampleInspection.expiry_date).startOf('day').toDate(), moment(expiryDate).startOf('day').toDate())
   }
 })


### PR DESCRIPTION
## Description

Update all newly generated sample inspections to have a status of issued

Update the category b samples to have an expiry date 6 months away from the latest reinstatement date

Street Manager Data: https://github.com/departmentfortransport/street-manager-data/pull/133
Street Manager Jobs: https://github.com/departmentfortransport/street-manager-jobs/pull/23
Street Manager Worker: https://github.com/departmentfortransport/street-manager-worker/pull/22

## Checklist

- [ ] All unit tests passing
- [ ] All integration tests passing
- [ ] Code coverage suitable
- [ ] Branch named {feature|hotfix|task}/{SM-.*}
- [ ] If your pull request depends on any other, please link them
- [ ] Changes approved by your team
- [ ] Changes approved by another team
- [ ] Commit messages are meaningful
- [ ] I have read and understand the [Jobs release process](https://github.com/departmentfortransport/street-manager-jobs#release-process)
- [ ] Target is green https://circleci.com/gh/departmentfortransport/street-manager-jobs/tree/master
- [ ] Int UI tests passing https://circleci.com/gh/departmentfortransport/street-manager-int/tree/master
- [ ] Add `DO NOT MERGE` if you want to postpone merge
