### PR TITLE
SM-6465: Only count issued sample inspections in number to generate

### DIFF
--- a/src/generate-sample-inspections/daos/sampleInspectionDao.ts
+++ b/src/generate-sample-inspections/daos/sampleInspectionDao.ts
@@ -49,9 +49,9 @@ export default class SampleInspectionDao {
       SELECT
         sample_inspection_target.sample_inspection_target_id,
         sample_inspection_target.promoter_organisation_id,
-        cap_category_a - (COUNT(sample_inspection.sample_inspection_id) FILTER (WHERE inspection_category_id=1)) AS category_a_to_generate,
-        cap_category_b - (COUNT(sample_inspection.sample_inspection_id) FILTER (WHERE inspection_category_id=2)) AS category_b_to_generate,
-        cap_category_c - (COUNT(sample_inspection.sample_inspection_id) FILTER (WHERE inspection_category_id=3)) AS category_c_to_generate
+        cap_category_a - (COUNT(sample_inspection.sample_inspection_id) FILTER (WHERE inspection_category_id=${RefInspectionCategory.a} AND sample_inspection_status_id=${RefSampleInspectionStatus.issued})) AS category_a_to_generate,
+        cap_category_b - (COUNT(sample_inspection.sample_inspection_id) FILTER (WHERE inspection_category_id=${RefInspectionCategory.b} AND sample_inspection_status_id=${RefSampleInspectionStatus.issued})) AS category_b_to_generate,
+        cap_category_c - (COUNT(sample_inspection.sample_inspection_id) FILTER (WHERE inspection_category_id=${RefInspectionCategory.c} AND sample_inspection_status_id=${RefSampleInspectionStatus.issued})) AS category_c_to_generate
       FROM sample_inspection
       RIGHT JOIN sample_inspection_target ON sample_inspection_target.sample_inspection_target_id = sample_inspection.sample_inspection_target_id
       WHERE sample_inspection_target.ha_organisation_id = ${organisationId}

--- a/tests/integration/helpers/sampleInspectionHelper.ts
+++ b/tests/integration/helpers/sampleInspectionHelper.ts
@@ -1,10 +1,17 @@
 import * as Knex from 'knex'
-import { SampleInspection } from 'street-manager-data'
+import { RefSampleInspectionStatus, SampleInspection } from 'street-manager-data'
 
 export async function getSampleInspections(knex: Knex, targetIds: number[], category: number[]): Promise<SampleInspection[]> {
   return await knex('sample_inspection')
     .whereIn('sample_inspection_target_id', targetIds)
     .whereIn('inspection_category_id', category)
+}
+
+export async function getSampleInspectionsByStatus(knex: Knex, targetIds: number[], category: number[], status: RefSampleInspectionStatus[]): Promise<SampleInspection[]> {
+  return await knex('sample_inspection')
+    .whereIn('sample_inspection_target_id', targetIds)
+    .whereIn('inspection_category_id', category)
+    .whereIn('sample_inspection_status_id', status)
 }
 
 export async function insertSampleInspection(knex: Knex, ...sampleInspection: SampleInspection[]): Promise<number[]> {


### PR DESCRIPTION
## Description

Only count issued sample inspections in number to generate

## Checklist

- [ ] All unit tests passing
- [ ] All integration tests passing
- [ ] Code coverage suitable
- [ ] Branch named {feature|hotfix|task}/{SM-.*}
- [ ] If your pull request depends on any other, please link them
- [ ] Changes approved by your team
- [ ] Changes approved by another team
- [ ] Commit messages are meaningful
- [ ] I have read and understand the [Jobs release process](https://github.com/departmentfortransport/street-manager-jobs#release-process)
- [ ] Target is green https://circleci.com/gh/departmentfortransport/street-manager-jobs/tree/master
- [ ] Int UI tests passing https://circleci.com/gh/departmentfortransport/street-manager-int/tree/master
- [ ] Add `DO NOT MERGE` if you want to postpone merge
