### PR TITLE
Feature/sm 6516 make email optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2776,8 +2776,8 @@
       }
     },
     "street-manager-data": {
-      "version": "git+ssh://git@github.com/departmentfortransport/street-manager-data.git#85a1206c86d5d209db7aedce6cd7bcddcd294fbc",
-      "from": "git+ssh://git@github.com/departmentfortransport/street-manager-data.git#85a1206c86d5d209db7aedce6cd7bcddcd294fbc",
+      "version": "git+ssh://git@github.com/departmentfortransport/street-manager-data.git#d86173b7a4d0f237103332d252e59a9f5142a91c",
+      "from": "git+ssh://git@github.com/departmentfortransport/street-manager-data.git#d86173b7a4d0f237103332d252e59a9f5142a91c",
       "requires": {
         "@types/geojson": "^7946.0.7",
         "knex": "^0.21.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2776,8 +2776,8 @@
       }
     },
     "street-manager-data": {
-      "version": "git+ssh://git@github.com/departmentfortransport/street-manager-data.git#28b55b2cd0a7a26e55b6119d5f55b7b3b34c7b04",
-      "from": "git+ssh://git@github.com/departmentfortransport/street-manager-data.git#28b55b2cd0a7a26e55b6119d5f55b7b3b34c7b04",
+      "version": "git+ssh://git@github.com/departmentfortransport/street-manager-data.git#a48f297c5ee35cac498cdeaa95cfd20bc90443cf",
+      "from": "git+ssh://git@github.com/departmentfortransport/street-manager-data.git#a48f297c5ee35cac498cdeaa95cfd20bc90443cf",
       "requires": {
         "@types/geojson": "^7946.0.7",
         "knex": "^0.21.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2776,8 +2776,8 @@
       }
     },
     "street-manager-data": {
-      "version": "git+ssh://git@github.com/departmentfortransport/street-manager-data.git#a48f297c5ee35cac498cdeaa95cfd20bc90443cf",
-      "from": "git+ssh://git@github.com/departmentfortransport/street-manager-data.git#a48f297c5ee35cac498cdeaa95cfd20bc90443cf",
+      "version": "git+ssh://git@github.com/departmentfortransport/street-manager-data.git#85a1206c86d5d209db7aedce6cd7bcddcd294fbc",
+      "from": "git+ssh://git@github.com/departmentfortransport/street-manager-data.git#85a1206c86d5d209db7aedce6cd7bcddcd294fbc",
       "requires": {
         "@types/geojson": "^7946.0.7",
         "knex": "^0.21.5",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "moment-timezone": "^0.5.28",
     "pg": "^8.0.3",
     "reflect-metadata": "^0.1.13",
-    "street-manager-data": "git+ssh://git@github.com:departmentfortransport/street-manager-data#85a1206c86d5d209db7aedce6cd7bcddcd294fbc"
+    "street-manager-data": "git+ssh://git@github.com:departmentfortransport/street-manager-data#d86173b7a4d0f237103332d252e59a9f5142a91c"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "moment-timezone": "^0.5.28",
     "pg": "^8.0.3",
     "reflect-metadata": "^0.1.13",
-    "street-manager-data": "git+ssh://git@github.com:departmentfortransport/street-manager-data#28b55b2cd0a7a26e55b6119d5f55b7b3b34c7b04"
+    "street-manager-data": "git+ssh://git@github.com:departmentfortransport/street-manager-data#a48f297c5ee35cac498cdeaa95cfd20bc90443cf"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "moment-timezone": "^0.5.28",
     "pg": "^8.0.3",
     "reflect-metadata": "^0.1.13",
-    "street-manager-data": "git+ssh://git@github.com:departmentfortransport/street-manager-data#a48f297c5ee35cac498cdeaa95cfd20bc90443cf"
+    "street-manager-data": "git+ssh://git@github.com:departmentfortransport/street-manager-data#85a1206c86d5d209db7aedce6cd7bcddcd294fbc"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",


### PR DESCRIPTION
## Description

Make email optional in organisation details page.

## Checklist

- [ ] All unit tests passing
- [ ] All integration tests passing
- [ ] Code coverage suitable
- [ ] Branch named {feature|hotfix|task}/{SM-.*}
- [ ] If your pull request depends on any other, please link them
- [ ] Changes approved by your team
- [ ] Changes approved by another team
- [ ] Commit messages are meaningful
- [ ] I have read and understand the [Jobs release process](https://github.com/departmentfortransport/street-manager-jobs#release-process)
- [ ] Target is green https://circleci.com/gh/departmentfortransport/street-manager-jobs/tree/master
- [ ] Int UI tests passing https://circleci.com/gh/departmentfortransport/street-manager-int/tree/master
- [ ] Add `DO NOT MERGE` if you want to postpone merge
