### PR TITLE
Feature/sm 6971 add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -3306,9 +3306,9 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
     },
     "yallist": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -483,16 +483,16 @@
       "dev": true
     },
     "chai": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
         "deep-eql": "^3.0.1",
         "get-func-name": "^2.0.0",
-        "pathval": "^1.1.0",
+        "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
       }
     },
@@ -2200,9 +2200,9 @@
       }
     },
     "pathval": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true
     },
     "pg": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/moment-timezone": "^0.5.12",
     "@types/node": "^10.12.12",
     "@types/sinon": "^5.0.7",
-    "chai": "^4.2.0",
+    "chai": "^4.3.4",
     "mocha": "^5.2.0",
     "nyc": "^14.1.1",
     "rimraf": "^2.6.2",


### PR DESCRIPTION
## Description

Bumps [chai](https://github.com/chaijs/chai) from 4.2.0 to 4.3.4.
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/chaijs/chai/releases">chai's releases</a>.</em></p>
<blockquote>
<h2>v4.3.4</h2>
<p>This fixes broken inspect behavior with bigints (<a href="https://github-redirect.dependabot.com/chaijs/chai/issues/1321">#1321</a>) (<a href="https://github-redirect.dependabot.com/chaijs/chai/issues/1383">#1383</a>) thanks <a href="https://github.com/vapier"><code>@​vapier</code></a></p>
<h2>4.3.3 / 2021-03-03</h2>
<p>This reintroduces <code>Assertion</code> as an export in the mjs file. See <a href="https://github-redirect.dependabot.com/chaijs/chai/pull/1378">chaijs/chai#1378</a> &amp; <a href="https://github-redirect.dependabot.com/chaijs/chai/issues/1375">chaijs/chai#1375</a></p>
<h2>4.3.2 / 2021-03-03</h2>
<p>This fixes a regression in IE11. See <a href="https://github-redirect.dependabot.com/chaijs/chai/pull/1380">chaijs/chai#1380</a> &amp; <a href="https://github-redirect.dependabot.com/chaijs/chai/issues/1379">chaijs/chai#1379</a></p>
<h2>4.3.1 / 2021-03-02</h2>
<p>This releases fixed an engine incompatibility with 4.3.0</p>
<p>The 4.x.x series of releases will be compatible with Node 4.0. Please report any errors found in Node 4 as bugs, and they will be fixed.</p>
<p>The 5.x.x series, when released, will drop support for Node 4.0</p>
<p>This fix also ensures <code>pathval</code> is updated to <code>1.1.1</code> to fix CVE-2020-7751</p>
<h2>4.3.0 / 2021-02-04</h2>
<p>This is a minor release.</p>
<p>Not many changes have got in since the last release but this one contains a very important change (<a href="https://github-redirect.dependabot.com/chaijs/chai/issues/1257">#1257</a>) which will allow <code>jest</code> users to get better diffs. From this release onwards, <code>jest</code> users will be able to see which operator was used in their diffs. <a href="https://nodejs.org/api/assert.html#assert_assert_deepstrictequal_actual_expected_message">The <code>operator</code> is a property of the <code>AssertionError</code> thrown when assertions fail</a>. This flag indicates what kind of comparison was made.</p>
<p>This is also an important change for plugin maintainers. Plugin maintainers will now have access to the <code>operator</code> <code>flag, which they can have access to through an </code>util<code>method called</code>getOperator`.</p>
<p>Thanks to all the amazing people that contributed to this release.</p>
<h1>New Features</h1>
<ul>
<li>Allow <code>contain.oneOf</code> to take an array of possible values (<a href="https://github.com/voliva"><code>@​voliva</code></a>)</li>
<li>Adding operator attribute to assertion error (<a href="https://github-redirect.dependabot.com/chaijs/chai/issues/1257">#1257</a>) (<a href="https://github.com/rpgeeganage"><code>@​rpgeeganage</code></a>)</li>
<li>The <code>closeTo</code> error message will now inform the user when a <code>delta</code> is required (<a href="https://github.com/eouw0o83hf"><code>@​eouw0o83hf</code></a>)</li>
</ul>
<h1>Docs</h1>
<ul>
<li>Add contains flag to oneOf documentation (<a href="https://github.com/voliva"><code>@​voliva</code></a>)</li>
</ul>
<h1>Tests</h1>
<ul>
<li>Make sure that <code>useProxy</code> config is checked in <code>overwriteProperty</code> (<a href="https://github.com/vieiralucas"><code>@​vieiralucas</code></a>)</li>
<li>Add tests for <code>contain.oneOf</code> (<a href="https://github.com/voliva"><code>@​voliva</code></a> )</li>
</ul>
<h1>Chores</h1>
<ul>
<li>Update mocha to version 6.1.4</li>
<li>Add node v10 and v12 to ci (<a href="https://github.com/vieiralucas"><code>@​vieiralucas</code></a>)</li>
<li>Drop support for node v4, v6 and v9 (<a href="https://github.com/vieiralucas"><code>@​vieiralucas</code></a>)</li>
<li>Fix sauce config for headless chrome (<a href="https://github.com/meeber"><code>@​meeber</code></a>)</li>
<li>Update dev dependencies (<a href="https://github.com/meeber"><code>@​meeber</code></a>)</li>
<li>Removed phantomjs dependency (<a href="https://github-redirect.dependabot.com/chaijs/chai/issues/1204">#1204</a>)</li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/chaijs/chai/commit/ab41ed86cc154e1df125b16e74abaa0d6f6ade82"><code>ab41ed8</code></a> 4.3.4</li>
<li><a href="https://github.com/chaijs/chai/commit/5b607a144eba37b0159582ff60d4e55d1a433026"><code>5b607a1</code></a> fix: support inspecting bigints (<a href="https://github-redirect.dependabot.com/chaijs/chai/issues/1321">#1321</a>) (<a href="https://github-redirect.dependabot.com/chaijs/chai/issues/1383">#1383</a>)</li>
<li><a href="https://github.com/chaijs/chai/commit/dc858a0353bb0eccca0de8185c140d4a1c1c6006"><code>dc858a0</code></a> chai@4.3.3</li>
<li><a href="https://github.com/chaijs/chai/commit/b0f50f6402572aa2f51712783e7138bd22be877f"><code>b0f50f6</code></a> export chai.Assertion (<a href="https://github-redirect.dependabot.com/chaijs/chai/issues/1378">#1378</a>)</li>
<li><a href="https://github.com/chaijs/chai/commit/3b9bc7f56dc0321e349ab145154052aae8056bdd"><code>3b9bc7f</code></a> chai@4.3.2</li>
<li><a href="https://github.com/chaijs/chai/commit/71245a3e33db0056d3de4ee9e5dee974ffbda8f4"><code>71245a3</code></a> Fixed a regression that caused SyntaxErrors on IE 11</li>
<li><a href="https://github.com/chaijs/chai/commit/8a246661566227db3d37019bb0bab3bbcdf45841"><code>8a24666</code></a> chai@4.3.1</li>
<li><a href="https://github.com/chaijs/chai/commit/9635906f8946a41d11352126257f6e0aaf2643a3"><code>9635906</code></a> chore: bump devdeps</li>
<li><a href="https://github.com/chaijs/chai/commit/c8449d31db01dffdbe8f8411087437245888e7f9"><code>c8449d3</code></a> fix: package.json - pathval to 1.1.1 (CVE-2020-7751) (<a href="https://github-redirect.dependabot.com/chaijs/chai/issues/1377">#1377</a>)</li>
<li><a href="https://github.com/chaijs/chai/commit/7bc01d6fc0741bccfdab7c84bec538c8879f93d7"><code>7bc01d6</code></a> fix: bring min node version in line with still supported (<a href="https://github-redirect.dependabot.com/chaijs/chai/issues/1374">#1374</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/chaijs/chai/compare/4.2.0...v4.3.4">compare view</a></li>
</ul>
</details>
<details>
<summary>Maintainer changes</summary>
<p>This version was pushed to npm by <a href="https://www.npmjs.com/~chai">chai</a>, a new releaser for chai since your current version.</p>
</details>
<br />


## Checklist

- [ ] All unit tests passing
- [ ] All integration tests passing
- [ ] Code coverage suitable
- [ ] Branch named {feature|hotfix|task}/{SM-.*}
- [ ] If your pull request depends on any other, please link them
- [ ] Changes approved by your team
- [ ] Changes approved by another team
- [ ] Commit messages are meaningful
- [ ] I have read and understand the [Jobs release process](https://github.com/departmentfortransport/street-manager-jobs#release-process)
- [ ] Target is green https://circleci.com/gh/departmentfortransport/street-manager-jobs/tree/master
- [ ] Int UI tests passing https://circleci.com/gh/departmentfortransport/street-manager-int/tree/master
- [ ] Add `DO NOT MERGE` if you want to postpone merge
